### PR TITLE
Added option for parsing Sauce credentials from env variables

### DIFF
--- a/extensions/sauce/SauceExtension.php
+++ b/extensions/sauce/SauceExtension.php
@@ -20,7 +20,9 @@ class SauceExtension extends \Codeception\Platform\Extension {
 	);
 
 	public function beforeTest(\Codeception\Event\TestEvent $e) {
-		$s = new SauceAPI($this->config['username'], $this->config['accesskey']);
+		$username = ($this->config['env_variables'] === true ? getenv('SAUCE_USERNAME') : $this->config['username']);
+		$accesskey = ($this->config['env_variables'] === true ? getenv('SAUCE_ACCESS_KEY') : $this->config['accesskey']);
+		$s = new SauceAPI($username, $accesskey);
 		$test = $e->getTest();
 		$newestTest = $this->getFirstJob($s);
 		try {
@@ -32,13 +34,17 @@ class SauceExtension extends \Codeception\Platform\Extension {
 	}
 
 	public function testFailed(\Codeception\Event\FailEvent $e) {
-		$s = new SauceAPI($this->config['username'], $this->config['accesskey']);
+		$username = ($this->config['env_variables'] === true ? getenv('SAUCE_USERNAME') : $this->config['username']);
+		$accesskey = ($this->config['env_variables'] === true ? getenv('SAUCE_ACCESS_KEY') : $this->config['accesskey']);
+		$s = new SauceAPI($username, $accesskey);
 		$newestTest = $this->getFirstJob($s);
 		$s->updateJob($newestTest['id'], array('passed' => false));
 	}
 
 	public function testSuccess(\Codeception\Event\TestEvent $e) {
-		$s = new SauceAPI($this->config['username'], $this->config['accesskey']);
+		$username = ($this->config['env_variables'] === true ? getenv('SAUCE_USERNAME') : $this->config['username']);
+		$accesskey = ($this->config['env_variables'] === true ? getenv('SAUCE_ACCESS_KEY') : $this->config['accesskey']);
+		$s = new SauceAPI($username, $accesskey);
 		$newestTest = $this->getFirstJob($s);
 		$s->updateJob($newestTest['id'], array('passed' => true));
 	}


### PR DESCRIPTION
Hi, this will read the Sauce username and access key from the corresponding environment variables (those used by Travis and Sauce Connect) if the env_variables option inside config is set to true. This is to avoid pushing Sauce credentials in cleartext to public repos if using something like Travis CI. There is a lot of unnecessary code reuse, so depending on your style, you may move this to static variables/initialization.